### PR TITLE
Fix PCP Invalid operation code

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -508,7 +508,8 @@ pub async fn peer_mapping(
 
     // PCP Requires a random value in [0.9, 1.1] be multiplied by the timeout.
     // <https://www.rfc-editor.org/rfc/rfc6887#section-8.1.1> Expands on PCP timing in detail.
-    let dist = rand::distr::Uniform::try_from(0.9..=1.1).expect("Failed to initialize uniform distribution");
+    let dist = rand::distr::Uniform::try_from(0.9..=1.1)
+        .expect("Failed to initialize uniform distribution");
     let fuzz_timeout = |wait: Duration| wait.mul_f64(rand::rng().sample(dist));
 
     // Try to get a response from the gateway.
@@ -803,7 +804,8 @@ async fn try_send_map_request(
 
     // PCP Requires a random value in [0.9, 1.1] be multiplied by the timeout.
     // <https://www.rfc-editor.org/rfc/rfc6887#section-8.1.1> Expands on PCP timing in detail.
-    let dist = rand::distr::Uniform::try_from(0.9..=1.1).expect("Failed to initialize uniform distribution");
+    let dist = rand::distr::Uniform::try_from(0.9..=1.1)
+        .expect("Failed to initialize uniform distribution");
     let fuzz_timeout = |wait: Duration| wait.mul_f64(rand::rng().sample(dist));
 
     let n =

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -939,17 +939,18 @@ fn validate_base_response(bb: &mut bytes::BytesMut) -> Result<ResponseHeader, Fa
     })
 }
 
-/// Request `OperationCode` bits are the same as the abstract `OperationCode`s, but left shifted by one.
+/// Request `OperationCode` bits are the same as the abstract
+/// `OperationCode`s but with MSb `R` bit (MSb) unset.
 fn opcode_to_request(op: OperationCode) -> u8 {
-    (op as u8) << 1
+    op as u8 & 0x7F
 }
 
-/// Response `OperationCode` bits are the same as the request `OperationCode`s, but with the `1` bit set.
-/// This function right shifts to align with the 7 bit code and attempts to parse as an `OperationCode`.
+/// Response `OperationCode` bits are the same as the request
+/// `OperationCode`s, but mask out `R` bit (MSb).
 fn response_to_opcode(
     op: u8,
 ) -> Result<OperationCode, num_enum::TryFromPrimitiveError<OperationCode>> {
-    OperationCode::try_from(op >> 1)
+    OperationCode::try_from(op & 0x7F)
 }
 
 /// Convert the `InternetProtocol` enum into the byte expected by the PCP protocol.

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -848,7 +848,7 @@ fn write_base_request(
 
     // Create the common PCP request header.
     bb.put_u8(VersionCode::Pcp as u8);
-    bb.put_u8(opcode_to_request(op));
+    bb.put_u8(op as u8); // Opcode with R bit unset.
     bb.put_u16(0); // Reserved.
     bb.put_u32(lifetime_seconds);
     bb.put(&client_ip6.octets()[..]);
@@ -946,12 +946,6 @@ fn validate_base_response(bb: &mut bytes::BytesMut) -> Result<ResponseHeader, Fa
         lifetime_seconds,
         gateway_epoch_seconds,
     })
-}
-
-/// Request `OperationCode` bits are the same as the abstract
-/// `OperationCode`s but with MSb `R` bit (MSb) unset.
-fn opcode_to_request(op: OperationCode) -> u8 {
-    op as u8 & 0x7F
 }
 
 /// Response `OperationCode` bits are the same as the request

--- a/src/pcp/tests.rs
+++ b/src/pcp/tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+#[test]
+fn test_validate_base_response_too_short() {
+    // Less than 24 bytes should return InvalidResponse
+    let mut bb = BytesMut::from(&[0u8; 16][..]);
+    let err = validate_base_response(&mut bb).unwrap_err();
+    assert!(matches!( err, Failure::InvalidResponse(ref msg)
+        if msg.contains("Too few bytes")
+    ));
+}
+
+#[test]
+fn test_validate_base_response_invalid_length() {
+    // More than 24 bytes but not a multiple of 4 bytes should return InvalidResponse
+    let mut bb = BytesMut::from(&[0u8; 27][..]);
+    let err = validate_base_response(&mut bb).unwrap_err();
+    assert!(matches!( err, Failure::InvalidResponse(ref msg)
+        if msg.contains("Invalid response length")
+    ));
+}
+
+#[test]
+fn test_validate_base_response_unsupported_version() {
+    // Correct length, but version is not required PCP version 2
+    let mut bb = BytesMut::with_capacity(24);
+    bb.put_u8(0xFF); // version (invalid)
+    bb.put_bytes(0u8, 23); // rest of header unchecked
+    let err = validate_base_response(&mut bb).unwrap_err();
+    assert!(matches!( err, Failure::InvalidResponse(ref msg)
+        if msg.contains("Unknown version")
+    ));
+}
+#[test]
+fn test_validate_base_response_unset_r_bit() {
+    // Correct length and version but R bit is not set
+    let mut bb = BytesMut::with_capacity(24);
+    bb.put_u8(VersionCode::Pcp as u8);
+    bb.put_u8(0x01); // opcode with R MSb unset
+    bb.put_bytes(0, 22); // rest of header unchecked
+    let err = validate_base_response(&mut bb).unwrap_err();
+    assert!(matches!( err, Failure::InvalidResponse(ref msg)
+        if msg.contains("Response R bit (MSb) must be set")
+    ));
+}
+#[test]
+fn test_validate_base_response_success() {
+    // 24 bytes, correct version, opcode, result code = Success
+    let mut bb = BytesMut::with_capacity(24);
+    bb.put_u8(VersionCode::Pcp as u8);
+    bb.put_u8(0x80 | OperationCode::Map as u8); // opcode with R MSb set
+    bb.put_u8(0x00); // reserved
+    bb.put_u8(ResultCode::Success as u8);
+    bb.put_u32(10); // lifetime
+    bb.put_u32(20); // epoch
+    bb.put_bytes(0, 12); // reserved
+    let res = validate_base_response(&mut bb).unwrap();
+    assert_eq!(res.lifetime_seconds, 10);
+    assert_eq!(res.gateway_epoch_seconds, 20);
+}


### PR DESCRIPTION
While testing the client with miniupnpd 2.2.1 on OpenWRT the following
error occurred:

     PCP(Invalid response: Invalid operation code: No discriminant in enum OperationCode matches the value 65)

The RFC describes a Response bit followed by 7-bit Opcode

```
 0 1 2 3 4 5 6 7
|R|   Opcode    |
```

With the original bit shifting would change the Opcode value so instead
we need to mask the response bit.

This is my first Rust PR so hopefully the changes and tests follow best practice...